### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,7 @@ Architecture: any
 Depends: ${misc:Depends},
          ${shlibs:Depends},
          libqt5sql5-sqlite,
-Description: simple, light and easy-to-use RSS/ATOM feed aggregator 
+Description: simple, light and easy-to-use RSS/ATOM feed aggregator
  RSS Guard is simple, light and easy-to-use RSS/ATOM feed aggregator
  developed using Qt framework which supports online feed synchronization
  with these services:

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,4 +1,4 @@
-Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: RSS Guard
 Upstream-Contact: Martin Rotter <rotter.martinos@gmail.com>
 Source: https://github.com/martinrotter/rssguard

--- a/debian/rules
+++ b/debian/rules
@@ -11,4 +11,3 @@ override_dh_auto_configure:
 execute_before_dh_install:
 	mkdir -p debian/rssguard$(PRIVATE_LIB_DIR)
 	mv debian/rssguard/usr/lib/librssguard.so debian/rssguard$(PRIVATE_LIB_DIR)
-

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,5 @@
+---
+Bug-Database: https://github.com/martinrotter/rssguard/issues
+Bug-Submit: https://github.com/martinrotter/rssguard/issues/new
+Repository: https://github.com/martinrotter/rssguard.git
+Repository-Browse: https://github.com/martinrotter/rssguard


### PR DESCRIPTION
Fix some issues reported by lintian

* Trim trailing whitespace. ([trailing-whitespace](https://lintian.debian.org/tags/trailing-whitespace))

* Use secure copyright file specification URI. ([insecure-copyright-format-uri](https://lintian.debian.org/tags/insecure-copyright-format-uri))

* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/rssguard/a6ebcb8c-0c4d-476a-93da-c99aacd11876.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/a6ebcb8c-0c4d-476a-93da-c99aacd11876/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/a6ebcb8c-0c4d-476a-93da-c99aacd11876/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/a6ebcb8c-0c4d-476a-93da-c99aacd11876/diffoscope)).
