### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,14 +2,14 @@ Source: rssguard
 Maintainer: Norbert Preining <norbert@preining.info>
 Section: kde
 Priority: optional
-Build-Depends: cmake (>= 3.9.0~),
+Build-Depends: cmake,
                debhelper-compat (= 13),
-               qtdeclarative5-dev (>= 5.10.0~),
-               qtmultimedia5-dev (>= 5.10.0~),
-               qtbase5-dev (>= 5.10.0~),
-               qttools5-dev (>= 5.10.0~),
-               qttools5-dev-tools (>= 5.10.0~),
-               qtwebengine5-dev (>= 5.10.0~),
+               qtdeclarative5-dev,
+               qtmultimedia5-dev,
+               qtbase5-dev,
+               qttools5-dev,
+               qttools5-dev-tools,
+               qtwebengine5-dev,
 Standards-Version: 4.5.1
 Vcs-Git: https://github.com/norbusan/rssguard-debian.git
 Vcs-Browser: https://github.com/norbusan/rssguard-debian


### PR DESCRIPTION
Remove unnecessary constraints.

## Debdiff

These changes affect the binary packages:

[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/49/aca09ded6cdbe3bbd40268aaec25c3b23db921.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/63/fe0433dba79fa19106c0c3b2a1801b9e84970d.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/1b/ddc1af437cd84e0ebcdae480e13191b394cc84.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/65/7c4b008f3c95b71474fbcb26556637833d1799.debug
### Control files of package rssguard: lines which differ (wdiff format)
* Depends: libc6 (>= 2.34), libgcc-s1 (>= 3.0), libqt5core5a (>= 5.15.1), libqt5dbus5 (>= [-5.10.0~),-] {+5.0.2),+} libqt5gui5 (>= 5.14.1) | libqt5gui5-gles (>= 5.14.1), libqt5multimedia5 (>= [-5.10.0~),-] {+5.6.0~beta),+} libqt5network5 (>= 5.15.1), libqt5qml5 (>= 5.12.2), libqt5sql5 (>= 5.10.0), libqt5webenginecore5 (>= [-5.10.0~),-] {+5.7.1),+} libqt5webenginewidgets5 (>= 5.14.1), libqt5widgets5 (>= 5.15.1), libqt5xml5 (>= [-5.10.0~),-] {+5.0.2),+} libstdc++6 (>= 11), libqt5sql5-sqlite
### Control files of package rssguard-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-1bddc1af437cd84e0ebcdae480e13191b394cc84 657c4b008f3c95b71474fbcb26556637833d1799-] {+49aca09ded6cdbe3bbd40268aaec25c3b23db921 63fe0433dba79fa19106c0c3b2a1801b9e84970d+}

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/2b9e6f68-8ca6-46cd-b96c-96674b0f4e66/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/2b9e6f68-8ca6-46cd-b96c-96674b0f4e66/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/scrub-obsolete), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/scrub-obsolete/pkg/rssguard/2b9e6f68-8ca6-46cd-b96c-96674b0f4e66.